### PR TITLE
[#10] OwnerShopServiceTest 동적 응답 객체 및 OwnerRepository 초기화 코드 수정

### DIFF
--- a/api/src/main/java/com/delivery_service/owners/repository/OwnerRepository.java
+++ b/api/src/main/java/com/delivery_service/owners/repository/OwnerRepository.java
@@ -1,7 +1,6 @@
 package com.delivery_service.owners.repository;
 
 import com.delivery_service.owners.entity.Owner;
-import jakarta.annotation.PostConstruct;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.springframework.stereotype.Repository;
@@ -11,8 +10,7 @@ public class OwnerRepository {
 
   private final ConcurrentMap<Integer, Owner> owners = new ConcurrentHashMap<>();
 
-  @PostConstruct
-  public void setOwners() {
+  public OwnerRepository() {
     Owner owner1 = new Owner(1);
     Owner owner2 = new Owner(2);
 

--- a/api/src/main/java/com/delivery_service/owners/service/OwnerShopService.java
+++ b/api/src/main/java/com/delivery_service/owners/service/OwnerShopService.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Service;
 @AllArgsConstructor
 public class OwnerShopService {
 
+  //TODO
+  //ownerService 구현하고, service에서 service를 의존하지 않도록 변경 예정
   private final OwnerRepository ownerRepository;
   private final OwnerShopRepository shopRepository;
 
@@ -21,7 +23,7 @@ public class OwnerShopService {
 //        }
 
     Shop savedShop = shopRepository.save(shop);
-    ownerRepository.saveShopId(owner, savedShop.getId());
+//    ownerRepository.saveShopId(owner, savedShop.getId());
 
     return savedShop;
   }

--- a/api/src/test/java/com/delivery_service/owners/service/OwnerShopServiceTest.java
+++ b/api/src/test/java/com/delivery_service/owners/service/OwnerShopServiceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.when;
 import com.delivery_service.owners.dto.ShopRegisterDto;
 import com.delivery_service.owners.entity.Owner;
 import com.delivery_service.owners.entity.Shop;
-import com.delivery_service.owners.repository.OwnerRepository;
 import com.delivery_service.owners.repository.OwnerShopRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,9 +17,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class OwnerShopServiceTest {
-
-  @Mock
-  OwnerRepository ownerRepository;
 
   @Mock
   OwnerShopRepository ownerShopRepository;
@@ -39,13 +35,10 @@ class OwnerShopServiceTest {
     registerDto.setCategory("패스트푸드");
     Shop shopToSave = registerDto.convertToEntity();
     Owner owner = new Owner(1);
-    when(ownerShopRepository.save(any(Shop.class))).thenAnswer(invocation -> {
-      int mockedShopId = 1;
-      Shop shop = invocation.getArgument(0);
-      shop.setId(mockedShopId);
 
-      return shop;
-    });
+    Shop savedShop = registerDto.convertToEntity();
+    savedShop.setId(1);
+    when(ownerShopRepository.save(any(Shop.class))).thenReturn(savedShop);
 
     //when
     Shop addedShop = ownerShopService.addShop(owner, shopToSave);


### PR DESCRIPTION
## 작업 내용
- OwnerShopServiceTest의 addShop() 메서드에서 Mock repository의 응답값을 정적인 객체를 생성해서 리턴하도록 수정하였습니다.
- OwnerRepository의 @PostConstruct가 실행 타이밍을 보장할 수 없기에 생성자에서 초기화하도록 수정하였습니다.

## 코멘트
- 피드백 주신대로 현재 OwnerShopService에서 두 repository를 사용중인데 OwnerService 구현 후 퍼사드 패턴을 적용해 볼 예정입니다.