### PR TITLE
DB 연동하기

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -5,5 +5,8 @@ plugins {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 }
 

--- a/api/src/main/java/com/delivery_service/owners/entity/Owner.java
+++ b/api/src/main/java/com/delivery_service/owners/entity/Owner.java
@@ -1,21 +1,35 @@
 package com.delivery_service.owners.entity;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
+@Entity
+@Table(name = "owner")
 @Getter
 @ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Owner {
 
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Integer id;
+
+  @Column(name = "shop_id")
+  @Setter
   private Integer shopId;
 
   public Owner(Integer id) {
     this.id = id;
   }
 
-  public void setShopId(Integer shopId) {
-    this.shopId = shopId;
-  }
 
 }

--- a/api/src/main/java/com/delivery_service/owners/entity/Shop.java
+++ b/api/src/main/java/com/delivery_service/owners/entity/Shop.java
@@ -1,18 +1,29 @@
 package com.delivery_service.owners.entity;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+@Entity
+@Table(name = "shop")
 @Getter
 @Setter
 @ToString
 public class Shop {
 
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Integer id;
   private String name;
   private String description;
   private String address;
+  @Column(name = "is_open", nullable = false)
   private Boolean isOpen;
   private String latitude;
   private String longitude;

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -13,6 +13,10 @@ spring:
       hibernate:
         format_sql: true #sql 포맷하여 출력
 
+  sql:
+    init:
+      mode: always
+
   data:
     redis:
       host: localhost

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/delivery_service
+    username: user
+    password: delivery_user0913
+
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: validate #Entity와의 매핑 판단만 테이블 변경x
+    properties:
+      hibernate:
+        format_sql: true #sql 포맷하여 출력
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+

--- a/api/src/main/resources/data.sql
+++ b/api/src/main/resources/data.sql
@@ -1,0 +1,7 @@
+DELETE
+FROM shop;
+DELETE
+FROM owner;
+INSERT INTO owner (id, shop_id)
+VALUES (1, NULL),
+       (2, NULL);

--- a/api/src/main/resources/logback-spring.xml
+++ b/api/src/main/resources/logback-spring.xml
@@ -13,7 +13,7 @@
     <appender-ref ref="STDOUT"/>
   </logger>
 
-  <root level="INFO">
+  <root level="DEBUG">
     <appender-ref ref="STDOUT"/>
   </root>
 </configuration>

--- a/api/src/main/resources/schema.sql
+++ b/api/src/main/resources/schema.sql
@@ -1,0 +1,19 @@
+
+CREATE TABLE IF NOT EXISTS shop (
+                      id INT PRIMARY KEY AUTO_INCREMENT,
+                      name VARCHAR(20) NOT NULL,
+                      address VARCHAR(255) NOT NULL,
+                      description TEXT NOT NULL,
+                      latitude VARCHAR(20) NOT NULL,
+                      longitude VARCHAR(20) NOT NULL,
+                      category VARCHAR(20) NOT NULL,
+                      image VARCHAR(255) NOT NULL,
+                      is_open BOOLEAN DEFAULT FALSE
+);
+
+CREATE TABLE IF NOT EXISTS owner (
+                       id INT PRIMARY KEY AUTO_INCREMENT ,
+                       shop_id INT
+);
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+
+  mysql:
+    image:
+      mysql:9.1.0
+    container_name: mysql_delivery
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: delivery_root0913
+      MYSQL_DATABASE: delivery_service
+      MYSQL_USER: user
+      MYSQL_PASSWORD: delivery_user0913
+      TZ: Asia/Seoul
+    ports:
+      - "3306:3306"
+    volumes:
+      - delivery-mysql-data:/var/libs/mysql
+
+  redis:
+    image:
+      redis:7.4
+    container_name: redis_delivery
+    restart: always
+    ports:
+      - "6379:6379"
+
+
+volumes:
+  delivery-mysql-data:


### PR DESCRIPTION
## 작업 내용
- docker compose를 이용해 redis,mysql 컨테이너를 실행했습니다.
- Jpa 사용을 위해 owner,shop entitiy 수정했습니다.
- script로 mysql 테이블 생성과 데이터를 저장했습니다.

## 문제점
- 뒤늦게 알아차렸는데 제가 처음에 RDB의 관계를 반대로 생각했습니다. 
owner가 shop_id를 가지는게 아니라 shop이 owner_id를 가지고 menu가 shop_id를 가져야 하는 것 같습니다. 
데이터의 무결성을 위해 rdb를 선택했는데 고민이 됩니다. 이미 만든 것을 수정할지 그냥 이 상태로 진행을 해도 되는지 고민중입니다.

- JPA를 처음사용하다보니 repository는 수정하지 못했습니다. 조금 더 공부해보겠습니다.