### PR TITLE
[#18] redis를 통해 로그인 유저 정보 캐싱 구현

### DIFF
--- a/api/src/main/java/com/delivery_service/common/UserRole.java
+++ b/api/src/main/java/com/delivery_service/common/UserRole.java
@@ -1,0 +1,17 @@
+package com.delivery_service.common;
+
+public enum UserRole {
+  Owner(com.delivery_service.owners.entity.Owner.class),
+  Customer(null),
+  Rider(null);
+
+  private final Class clazz;
+
+  UserRole(Class clazz) {
+    this.clazz = clazz;
+  }
+
+  public Class getClazz() {
+    return clazz;
+  }
+}

--- a/api/src/main/java/com/delivery_service/common/annotation/User.java
+++ b/api/src/main/java/com/delivery_service/common/annotation/User.java
@@ -1,5 +1,6 @@
-package com.delivery_service.owners.annotation;
+package com.delivery_service.common.annotation;
 
+import com.delivery_service.common.UserRole;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -7,6 +8,8 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface OwnerLogin {
+public @interface User {
+
+  UserRole role();
 
 }

--- a/api/src/main/java/com/delivery_service/common/config/RedisConfig.java
+++ b/api/src/main/java/com/delivery_service/common/config/RedisConfig.java
@@ -1,0 +1,28 @@
+package com.delivery_service.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+  @Bean
+  LettuceConnectionFactory connectionFactory() {
+    return new LettuceConnectionFactory();
+  }
+
+  @Bean
+  RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+    RedisTemplate<String, String> template = new RedisTemplate<>();
+    template.setConnectionFactory(connectionFactory);
+    template.setKeySerializer(new StringRedisSerializer());
+    template.setValueSerializer(new StringRedisSerializer());
+
+    return template;
+  }
+
+}

--- a/api/src/main/java/com/delivery_service/common/config/WebConfig.java
+++ b/api/src/main/java/com/delivery_service/common/config/WebConfig.java
@@ -1,6 +1,6 @@
 package com.delivery_service.common.config;
 
-import com.delivery_service.owners.resolver.OwnerArgumentResolver;
+import com.delivery_service.common.resolver.LoginUserInfoArgumentResolver;
 import java.util.List;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -9,15 +9,15 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-  private final OwnerArgumentResolver ownerArgumentResolver;
+  private final LoginUserInfoArgumentResolver loginUserInfoArgumentResolver;
 
-  public WebConfig(OwnerArgumentResolver ownerArgumentResolver) {
-    this.ownerArgumentResolver = ownerArgumentResolver;
+  public WebConfig(LoginUserInfoArgumentResolver loginUserInfoArgumentResolver) {
+    this.loginUserInfoArgumentResolver = loginUserInfoArgumentResolver;
   }
 
   @Override
   public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-    resolvers.add(ownerArgumentResolver);
+    resolvers.add(loginUserInfoArgumentResolver);
   }
 
 }

--- a/api/src/main/java/com/delivery_service/common/entity/LoginUser.java
+++ b/api/src/main/java/com/delivery_service/common/entity/LoginUser.java
@@ -1,0 +1,28 @@
+package com.delivery_service.common.entity;
+
+import com.delivery_service.common.UserRole;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginUser {
+
+  @Id
+  private String token;
+  @Enumerated(EnumType.STRING)
+  private UserRole role;
+  private Integer userId;
+
+}

--- a/api/src/main/java/com/delivery_service/common/entity/LoginUserInfo.java
+++ b/api/src/main/java/com/delivery_service/common/entity/LoginUserInfo.java
@@ -1,0 +1,19 @@
+package com.delivery_service.common.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+
+public class LoginUserInfo<T> {
+
+  private LoginUser loginUser;
+  private T user;
+
+
+}

--- a/api/src/main/java/com/delivery_service/common/facade/LoginUserInfoFacade.java
+++ b/api/src/main/java/com/delivery_service/common/facade/LoginUserInfoFacade.java
@@ -1,0 +1,82 @@
+package com.delivery_service.common.facade;
+
+import com.delivery_service.common.UserRole;
+import com.delivery_service.common.entity.LoginUser;
+import com.delivery_service.common.entity.LoginUserInfo;
+import com.delivery_service.common.service.LoginUserInfoCacheService;
+import com.delivery_service.common.service.LoginUserService;
+import com.delivery_service.owners.service.OwnerService;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@AllArgsConstructor
+@Slf4j
+public class LoginUserInfoFacade {
+
+  private final LoginUserInfoCacheService loginUserInfoCacheService;
+  private final LoginUserService loginUserService;
+  private final OwnerService ownerService;
+
+
+  public <T> LoginUserInfo<T> getLoginUserInfo(UserRole userRole, String token) {
+
+    LoginUserInfo<T> cache = loginUserInfoCacheService.getLoginUserInfo(token, userRole);
+    if (cache != null) {
+      //캐시에 저장되어있을 때
+      log.debug("cache hit key={}", token);
+      return cache;
+    }
+
+    //캐시에 없을 때 db에서 select
+    log.debug("cache miss key={}", token);
+    LoginUser loginUser = loginUserService.getLoginUser(token);
+    if (loginUser != null) {
+      T user = null;
+      switch (userRole) {
+        case Owner:
+          user = (T) ownerService.getOwner(loginUser.getUserId());
+
+        case Customer:
+
+          break;
+
+        case Rider:
+          break;
+
+      }
+
+      return new LoginUserInfo<>(loginUser, user);
+    }
+
+    //캐시,db 둘 다 없을때
+    return null;
+  }
+
+  public <T> T saveLoginUserInfo(UserRole userRole, String token,
+      Integer userId) {
+    LoginUser loginUser = new LoginUser(token, userRole, userId);
+
+    //db저장
+    loginUserService.saveLoginUser(loginUser);
+    T user = null;
+    switch (userRole) {
+      case Owner:
+        user = (T) ownerService.getOwner(userId);
+        break;
+      case Customer:
+        break;
+      case Rider:
+        break;
+
+    }
+
+    LoginUserInfo<T> loginUserInfo = new LoginUserInfo<>(loginUser, user);
+
+    //캐시저장
+    loginUserInfoCacheService.saveLoginUserInfo(token, loginUserInfo);
+    return user;
+
+  }
+}

--- a/api/src/main/java/com/delivery_service/common/repository/LoginUserRepository.java
+++ b/api/src/main/java/com/delivery_service/common/repository/LoginUserRepository.java
@@ -1,0 +1,10 @@
+package com.delivery_service.common.repository;
+
+import com.delivery_service.common.entity.LoginUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LoginUserRepository extends JpaRepository<LoginUser, String> {
+
+}

--- a/api/src/main/java/com/delivery_service/common/resolver/LoginUserInfoArgumentResolver.java
+++ b/api/src/main/java/com/delivery_service/common/resolver/LoginUserInfoArgumentResolver.java
@@ -1,0 +1,66 @@
+package com.delivery_service.common.resolver;
+
+import com.delivery_service.common.UserRole;
+import com.delivery_service.common.annotation.User;
+import com.delivery_service.common.entity.LoginUserInfo;
+import com.delivery_service.common.facade.LoginUserInfoFacade;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@Slf4j
+@AllArgsConstructor
+public class LoginUserInfoArgumentResolver implements HandlerMethodArgumentResolver {
+
+  private final LoginUserInfoFacade loginUserInfoFacade;
+
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    boolean hasUserAnnotation = parameter.hasParameterAnnotation(User.class);
+
+    //TODO Customer.class Rider.class 추가
+    boolean isLoginUserInfo = LoginUserInfo.class.isAssignableFrom(parameter.getParameterType());
+    log.debug("hasUserAnnotation = {}, isLoginUserInfo = {}", hasUserAnnotation,
+        isLoginUserInfo);
+
+    return hasUserAnnotation && isLoginUserInfo;
+  }
+
+  @Override
+  public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+      NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+    UserRole userRole = parameter.getParameterAnnotation(User.class).role();
+
+    String authorization = getAuthorization(webRequest);
+
+    if (authorization != null && authorization.startsWith("Bearer ")) {
+
+      String token = getToken(authorization);
+
+      return loginUserInfoFacade.getLoginUserInfo(userRole, token);
+    }
+    return null;
+  }
+
+  private String getToken(String authorization) {
+
+    String token = authorization.split(" ")[1];
+    log.debug("token = {}", token);
+    return token;
+  }
+
+  private String getAuthorization(NativeWebRequest webRequest) {
+    HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+    String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+    log.debug("authorization = {}", authorization);
+    return authorization;
+  }
+}

--- a/api/src/main/java/com/delivery_service/common/service/LoginUserInfoCacheService.java
+++ b/api/src/main/java/com/delivery_service/common/service/LoginUserInfoCacheService.java
@@ -1,0 +1,59 @@
+package com.delivery_service.common.service;
+
+import com.delivery_service.common.UserRole;
+import com.delivery_service.common.entity.LoginUserInfo;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+@Slf4j
+public class LoginUserInfoCacheService {
+
+  private final RedisTemplate<String, String> redisTemplate;
+
+  public <T> LoginUserInfo<T> getLoginUserInfo(String token, UserRole userRole) {
+    String key = getKey(userRole, token);
+    String data = redisTemplate.opsForValue().get(key);
+    if (data == null) {
+      return null;
+    }
+
+    try {
+      ObjectMapper objectMapper = new ObjectMapper();
+      JavaType javaType = objectMapper.getTypeFactory()
+          .constructParametricType(LoginUserInfo.class, userRole.getClazz());
+      return objectMapper.readValue(data, javaType);
+
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public <T> void saveLoginUserInfo(String token, LoginUserInfo<T> user) {
+    String key = getKey(user.getLoginUser().getRole(), token);
+    try {
+      log.debug("key={}", key);
+      ObjectMapper objectMapper = new ObjectMapper();
+      String data = objectMapper.writeValueAsString(user);
+      redisTemplate.opsForValue().set(key, data);
+
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+
+  }
+
+  private String getKey(UserRole type, String token) {
+    String key = type.name().toLowerCase() + ":" + token;
+    log.debug("setKeyPrefix key={}", key);
+    return key;
+  }
+
+
+}

--- a/api/src/main/java/com/delivery_service/common/service/LoginUserService.java
+++ b/api/src/main/java/com/delivery_service/common/service/LoginUserService.java
@@ -1,0 +1,22 @@
+package com.delivery_service.common.service;
+
+import com.delivery_service.common.entity.LoginUser;
+import com.delivery_service.common.repository.LoginUserRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class LoginUserService {
+
+  private final LoginUserRepository loginUserRepository;
+
+  public LoginUser saveLoginUser(LoginUser loginUser) {
+    return loginUserRepository.save(loginUser);
+  }
+
+  public LoginUser getLoginUser(String token) {
+    return loginUserRepository.findById(token).get();
+  }
+
+}

--- a/api/src/main/java/com/delivery_service/common/service/LoginUserService.java
+++ b/api/src/main/java/com/delivery_service/common/service/LoginUserService.java
@@ -9,14 +9,14 @@ import org.springframework.stereotype.Service;
 @AllArgsConstructor
 public class LoginUserService {
 
-  private final LoginUserRepository loginUserRepository;
+  private final LoginUserRepository repository;
 
   public LoginUser saveLoginUser(LoginUser loginUser) {
-    return loginUserRepository.save(loginUser);
+    return repository.save(loginUser);
   }
 
   public LoginUser getLoginUser(String token) {
-    return loginUserRepository.findById(token).get();
+    return repository.findById(token).get();
   }
 
 }

--- a/api/src/main/java/com/delivery_service/owners/repository/OwnerRepository.java
+++ b/api/src/main/java/com/delivery_service/owners/repository/OwnerRepository.java
@@ -1,28 +1,9 @@
 package com.delivery_service.owners.repository;
 
 import com.delivery_service.owners.entity.Owner;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-@Repository
-public class OwnerRepository {
+public interface OwnerRepository extends JpaRepository<Owner, Integer> {
 
-  private final ConcurrentMap<Integer, Owner> owners = new ConcurrentHashMap<>();
 
-  public OwnerRepository() {
-    Owner owner1 = new Owner(1);
-    Owner owner2 = new Owner(2);
-
-    owners.put(1, owner1);
-    owners.put(2, owner2);
-  }
-
-  public Owner findById(Integer id) {
-    return owners.get(id);
-  }
-
-  public void update(Owner owner) {
-    owners.replace(owner.getId(), owner);
-  }
 }

--- a/api/src/main/java/com/delivery_service/owners/repository/OwnerShopRepository.java
+++ b/api/src/main/java/com/delivery_service/owners/repository/OwnerShopRepository.java
@@ -1,52 +1,11 @@
 package com.delivery_service.owners.repository;
 
 import com.delivery_service.owners.entity.Shop;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicInteger;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Slf4j
 @Repository
-public class OwnerShopRepository {
+public interface OwnerShopRepository extends JpaRepository<Shop, Integer> {
 
-  private ConcurrentMap<Integer, Shop> storage = new ConcurrentHashMap<>();
-  private AtomicInteger shopIdCounter = new AtomicInteger(0);
 
-  public Shop save(Shop shop) {
-    Integer shopId = shopIdCounter.incrementAndGet();
-    shop.setId(shopId);
-    log.debug("shop = {}", shop);
-    storage.put(shopId, shop);
-
-    return storage.get(shopId);
-  }
-
-  public Shop findByShopId(Integer shopId) {
-    Shop shop = storage.get(shopId);
-    log.debug("shop = {}", shop);
-
-    return shop;
-  }
-
-  public Shop update(Integer shopId, Shop shop) {
-    log.debug("shop = {}", shop);
-
-    storage.replace(shopId, shop);
-    return storage.get(shopId);
-  }
-
-  public Boolean updateIsOpen(Integer shopId, Boolean isOpen) {
-    Shop shop = storage.get(shopId);
-    shop.setIsOpen(isOpen);
-    log.debug("shop.isOpen = {}", shop.getIsOpen());
-
-    return shop.getIsOpen();
-  }
-
-  public void clear() {
-    storage.clear();
-    shopIdCounter.set(0);
-  }
 }

--- a/api/src/main/java/com/delivery_service/owners/service/OwnerService.java
+++ b/api/src/main/java/com/delivery_service/owners/service/OwnerService.java
@@ -9,13 +9,13 @@ import org.springframework.stereotype.Service;
 @Service
 public class OwnerService {
 
-  private final OwnerRepository ownerRepository;
+  private final OwnerRepository repository;
 
   public Owner getOwner(Integer ownerId) {
-    return ownerRepository.findById(ownerId);
+    return repository.findById(ownerId).get();
   }
 
   public void updateOwner(Owner owner) {
-    ownerRepository.update(owner);
+    repository.save(owner);
   }
 }

--- a/api/src/main/java/com/delivery_service/owners/service/OwnerShopService.java
+++ b/api/src/main/java/com/delivery_service/owners/service/OwnerShopService.java
@@ -5,12 +5,13 @@ import com.delivery_service.owners.entity.Shop;
 import com.delivery_service.owners.repository.OwnerShopRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @AllArgsConstructor
 public class OwnerShopService {
 
-  private final OwnerShopRepository shopRepository;
+  private final OwnerShopRepository repository;
 
   public Shop addShop(Owner owner, Shop shop) {
     //이미 shop을 가지고 있을 경우?
@@ -18,7 +19,7 @@ public class OwnerShopService {
 //
 //        }
 
-    Shop savedShop = shopRepository.save(shop);
+    Shop savedShop = repository.save(shop);
 
     return savedShop;
   }
@@ -28,17 +29,20 @@ public class OwnerShopService {
 //        if(owner.getShopId() == null){
 //
 //        }
-    return shopRepository.findByShopId(owner.getShopId());
+    return repository.findById(owner.getShopId()).get();
   }
 
   public Shop updateShop(Owner owner, Shop shop) {
     //owner가 가지는 shopId 와 요청으로 온 shop의 shopId가 다르면?
 
-    return shopRepository.update(owner.getShopId(), shop);
+    return repository.save(shop);
   }
 
+  @Transactional
   public Boolean updateShopStatus(Owner owner, Boolean isOpen) {
-    return shopRepository.updateIsOpen(owner.getShopId(), isOpen);
+    Shop shop = repository.findById(owner.getShopId()).get();
+    shop.setIsOpen(isOpen);
+    return shop.getIsOpen();
   }
 
 }

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -6,12 +6,13 @@ spring:
     password: delivery_user0913
 
   jpa:
-    show-sql: true
     hibernate:
       ddl-auto: validate #Entity와의 매핑 판단만 테이블 변경x
     properties:
       hibernate:
-        format_sql: true #sql 포맷하여 출력
+        show_sql: false
+        format_sql: true
+
 
   sql:
     init:

--- a/api/src/main/resources/logback-spring.xml
+++ b/api/src/main/resources/logback-spring.xml
@@ -9,7 +9,10 @@
     </encoder>
   </appender>
 
-  <logger name="com.delivery_service" level="debug">
+  <logger name="org.hibernate.SQL" level="DEBUG">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+  <logger name="com.delivery_service" level="DEBUG">
     <appender-ref ref="STDOUT"/>
   </logger>
 

--- a/api/src/main/resources/schema.sql
+++ b/api/src/main/resources/schema.sql
@@ -4,10 +4,10 @@ CREATE TABLE IF NOT EXISTS shop (
                       name VARCHAR(20) NOT NULL,
                       address VARCHAR(255) NOT NULL,
                       description TEXT NOT NULL,
-                      latitude VARCHAR(20) NOT NULL,
-                      longitude VARCHAR(20) NOT NULL,
+                      latitude VARCHAR(20),
+                      longitude VARCHAR(20),
                       category VARCHAR(20) NOT NULL,
-                      image VARCHAR(255) NOT NULL,
+                      image VARCHAR(255),
                       is_open BOOLEAN DEFAULT FALSE
 );
 

--- a/api/src/main/resources/schema.sql
+++ b/api/src/main/resources/schema.sql
@@ -1,19 +1,27 @@
-
-CREATE TABLE IF NOT EXISTS shop (
-                      id INT PRIMARY KEY AUTO_INCREMENT,
-                      name VARCHAR(20) NOT NULL,
-                      address VARCHAR(255) NOT NULL,
-                      description TEXT NOT NULL,
-                      latitude VARCHAR(20),
-                      longitude VARCHAR(20),
-                      category VARCHAR(20) NOT NULL,
-                      image VARCHAR(255),
-                      is_open BOOLEAN DEFAULT FALSE
+CREATE TABLE IF NOT EXISTS shop
+(
+    id          INT PRIMARY KEY AUTO_INCREMENT,
+    name        VARCHAR(20)  NOT NULL,
+    address     VARCHAR(255) NOT NULL,
+    description TEXT         NOT NULL,
+    latitude    VARCHAR(20),
+    longitude   VARCHAR(20),
+    category    VARCHAR(20)  NOT NULL,
+    image       VARCHAR(255),
+    is_open     BOOLEAN DEFAULT FALSE
 );
 
-CREATE TABLE IF NOT EXISTS owner (
-                       id INT PRIMARY KEY AUTO_INCREMENT ,
-                       shop_id INT
+CREATE TABLE IF NOT EXISTS owner
+(
+    id      INT PRIMARY KEY AUTO_INCREMENT,
+    shop_id INT
 );
+
+CREATE TABLE IF NOT EXISTS login_user
+(
+    token   VARCHAR(36) PRIMARY KEY,
+    role    VARCHAR(10) NOT NULL,
+    user_id INT         NOT NULL
+)
 
 


### PR DESCRIPTION
## 작업 내용
- login_user(token, role, user_id)테이블을 통해 로그인 사용자 정보 저장
- redis를 통해 사용자 정보 캐싱하여 argumentResolver를 통해 controller에 전달
- 사용자의 role에 관계없이 LoginUserArgumentResolver를 통해 LoginUserInfo를 가져오도록 구현

## 문제점
- 한 곳에서 모든 사용자 정보를 가져오려다 보니 redis의 json 데이터를 해당 사용자 object로 파싱하는데 문제가 생겨 제네릭과 objectMapper를 통해 가져오도록 하였습니다. 코드 재사용을 피하려다 로직이 복잡해진 것은 아닌가 하는 생각이 듭니다.
- redis에서 owner정보를 저장하다보니 controller의 addshop에서 shop을 저장한 후에 null로 되어있는 redis의 shopId를 업데이트 해야되는 상황이 생겼습니다. 그러다보니 controller에서 redis 키 값이 필요하여 argumentResolver에서 전달되는 파라미터를 Owner에서 LoginUserInfo 객체로 변경하였습니다. addShop에서만 사용되는 정보를 위해 다른 api메소드에서 불필요한 것을 다 가져다 쓰는 것 같다는 생각이 듭니다.