### PR TITLE
[#27] 이미지 업로드를 위한  presignedUrl 발급 API추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ build
 
 # 인텔리제이 파일
 .idea
+
+# api키
+api-key.yml

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -8,5 +8,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    implementation platform("software.amazon.awssdk:bom:2.30.7")
+    implementation 'software.amazon.awssdk:s3'
+
 }
 

--- a/api/src/main/java/com/delivery_service/common/config/NCPStorageConfig.java
+++ b/api/src/main/java/com/delivery_service/common/config/NCPStorageConfig.java
@@ -1,0 +1,39 @@
+package com.delivery_service.common.config;
+
+import java.net.URI;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+@ConfigurationProperties(prefix = "ncp.storage")
+@Getter
+@Setter
+public class NCPStorageConfig {
+
+  private String endpoint;
+  private String accessKey;
+  private String secretKey;
+  private String region;
+  private String bucket;
+
+  @Bean
+  public S3Presigner s3Presigner() {
+    AwsBasicCredentials credentials = AwsBasicCredentials.builder()
+        .accessKeyId(accessKey)
+        .secretAccessKey(secretKey)
+        .build();
+
+    return S3Presigner.builder()
+        .region(Region.of(region))
+        .credentialsProvider(StaticCredentialsProvider.create(credentials))
+        .endpointOverride(URI.create(endpoint))
+        .build();
+  }
+}

--- a/api/src/main/java/com/delivery_service/common/dto/ImageUploadReqDto.java
+++ b/api/src/main/java/com/delivery_service/common/dto/ImageUploadReqDto.java
@@ -1,0 +1,12 @@
+package com.delivery_service.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ImageUploadReqDto {
+
+  String originalImageName;
+
+}

--- a/api/src/main/java/com/delivery_service/common/dto/ImageUrlDto.java
+++ b/api/src/main/java/com/delivery_service/common/dto/ImageUrlDto.java
@@ -1,0 +1,13 @@
+package com.delivery_service.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ImageUrlDto {
+
+  private String urlForUpload;
+  private String urlForDownload;
+
+}

--- a/api/src/main/java/com/delivery_service/common/service/ImageUrlService.java
+++ b/api/src/main/java/com/delivery_service/common/service/ImageUrlService.java
@@ -1,0 +1,62 @@
+package com.delivery_service.common.service;
+
+import java.time.Duration;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ImageUrlService {
+
+  @Value("${ncp.storage.bucket}")
+  private String bucket;
+  private final S3Presigner s3Presigner;
+  private final long expMinute = 60;
+
+  public static final String USAGE_SHOP = "shop";
+  public static final String USAGE_MENU = "menu";
+
+  public String getPresignedUrl(String usage, String originalImageName) {
+    String key = generateKey(usage, originalImageName);
+
+    AwsRequestOverrideConfiguration override = AwsRequestOverrideConfiguration.builder()
+        .putRawQueryParameter("x-amz-acl", "public-read")//업로드 후 public 읽기 설정
+        .build();
+
+    PutObjectPresignRequest putObjectPresignRequest = PutObjectPresignRequest.builder()
+        .signatureDuration(Duration.ofMinutes(expMinute)) // 10분 동안 유효
+        .putObjectRequest(PutObjectRequest.builder()
+            .bucket(bucket)
+            .key(key)
+            .overrideConfiguration(override)
+            .build())
+        .build();
+
+    PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(
+        putObjectPresignRequest);
+    log.debug("presignedUrl={}", presignedRequest.url());
+
+    return presignedRequest.url().toString();
+  }
+
+  public String getPublicUrl(String presignedUrl) {
+    return presignedUrl.split("\\?")[0];
+  }
+
+  private String generateKey(String folder, String filename) {
+    UUID uuid = UUID.randomUUID();
+    String ext = filename.substring(filename.lastIndexOf("."));
+
+    return folder + "/" + uuid.toString() + ext;
+  }
+
+}

--- a/api/src/main/java/com/delivery_service/owners/controller/OwnerMenuController.java
+++ b/api/src/main/java/com/delivery_service/owners/controller/OwnerMenuController.java
@@ -2,7 +2,10 @@ package com.delivery_service.owners.controller;
 
 import com.delivery_service.common.UserRole;
 import com.delivery_service.common.annotation.User;
+import com.delivery_service.common.dto.ImageUploadReqDto;
+import com.delivery_service.common.dto.ImageUrlDto;
 import com.delivery_service.common.response.CommonResponse;
+import com.delivery_service.common.service.ImageUrlService;
 import com.delivery_service.owners.dto.MenuInfoDto;
 import com.delivery_service.owners.dto.MenuRegisterDto;
 import com.delivery_service.owners.dto.MenuStatusDto;
@@ -14,7 +17,6 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,13 +24,15 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @AllArgsConstructor
 @RequestMapping("/owners/menus")
 public class OwnerMenuController {
 
   private final OwnerMenuService ownerMenuService;
+  private final ImageUrlService imageUrlService;
 
   @PostMapping
   public ResponseEntity<CommonResponse<MenuInfoDto>> addMenu(
@@ -76,6 +80,21 @@ public class OwnerMenuController {
     }
 
     CommonResponse<ArrayList<MenuInfoDto>> response = CommonResponse.success(MenusDto);
+
+    return new ResponseEntity<>(response, HttpStatus.OK);
+  }
+
+  @PostMapping("/image-url")
+  public ResponseEntity<CommonResponse<ImageUrlDto>> getShopImageUrl(
+      @User(role = UserRole.Owner) Owner owner, @RequestBody ImageUploadReqDto imageUploadReqDto) {
+
+    String shopImageUploadUrl = imageUrlService.getPresignedUrl(ImageUrlService.USAGE_MENU,
+        imageUploadReqDto.getOriginalImageName());
+    String shopImageDownloadUrl = imageUrlService.getPublicUrl(shopImageUploadUrl);
+
+    ImageUrlDto imageUrlDto = new ImageUrlDto(shopImageUploadUrl, shopImageDownloadUrl);
+
+    CommonResponse<ImageUrlDto> response = CommonResponse.success(imageUrlDto);
 
     return new ResponseEntity<>(response, HttpStatus.OK);
   }

--- a/api/src/main/java/com/delivery_service/owners/controller/OwnerShopController.java
+++ b/api/src/main/java/com/delivery_service/owners/controller/OwnerShopController.java
@@ -2,6 +2,8 @@ package com.delivery_service.owners.controller;
 
 import com.delivery_service.common.UserRole;
 import com.delivery_service.common.annotation.User;
+import com.delivery_service.common.dto.ImageUploadReqDto;
+import com.delivery_service.common.dto.ImageUrlDto;
 import com.delivery_service.common.response.CommonResponse;
 import com.delivery_service.owners.dto.ShopInfoDto;
 import com.delivery_service.owners.dto.ShopRegisterDto;
@@ -82,6 +84,20 @@ public class OwnerShopController {
     shopStatusDto.setIsOpen(isOpen);
 
     CommonResponse<ShopStatusDto> response = CommonResponse.success(shopStatusDto);
+
+    return new ResponseEntity<>(response, HttpStatus.OK);
+  }
+
+  @PostMapping("/image-url")
+  public ResponseEntity<CommonResponse<ImageUrlDto>> getShopImageUrl(
+      @User(role = UserRole.Owner) Owner owner, @RequestBody ImageUploadReqDto imageUploadReqDto) {
+    String shopImageUploadUrl = ownerShopFacade.getShopImageUploadUrl(
+        imageUploadReqDto.getOriginalImageName());
+    String shopImageDownloadUrl = ownerShopFacade.getShopImageDownloadUrl(shopImageUploadUrl);
+
+    ImageUrlDto imageUrlDto = new ImageUrlDto(shopImageUploadUrl, shopImageDownloadUrl);
+
+    CommonResponse<ImageUrlDto> response = CommonResponse.success(imageUrlDto);
 
     return new ResponseEntity<>(response, HttpStatus.OK);
   }

--- a/api/src/main/java/com/delivery_service/owners/facade/OwnerShopFacade.java
+++ b/api/src/main/java/com/delivery_service/owners/facade/OwnerShopFacade.java
@@ -3,6 +3,7 @@ package com.delivery_service.owners.facade;
 import com.delivery_service.common.UserRole;
 import com.delivery_service.common.dto.LoginUserInfo;
 import com.delivery_service.common.entity.LoginUser;
+import com.delivery_service.common.service.ImageUrlService;
 import com.delivery_service.common.service.LoginUserInfoCacheService;
 import com.delivery_service.common.service.LoginUserService;
 import com.delivery_service.owners.entity.Owner;
@@ -22,6 +23,7 @@ public class OwnerShopFacade {
   private final OwnerShopService ownerShopService;
   private final LoginUserService loginUserService;
   private final LoginUserInfoCacheService loginUserInfoCacheService;
+  private final ImageUrlService imageUrlService;
 
   public Shop addShop(Owner owner, Shop shop) {
     Shop savedShop = ownerShopService.addShop(owner, shop);
@@ -45,6 +47,14 @@ public class OwnerShopFacade {
 
   public Boolean updateShopStatus(Owner owner, Boolean isOpen) {
     return ownerShopService.updateShopStatus(owner, isOpen);
+  }
+
+  public String getShopImageUploadUrl(String originalImageName) {
+    return imageUrlService.getPresignedUrl(ImageUrlService.USAGE_SHOP, originalImageName);
+  }
+
+  public String getShopImageDownloadUrl(String presignedUrl) {
+    return imageUrlService.getPublicUrl(presignedUrl);
   }
 
 

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -23,3 +23,6 @@ spring:
       host: localhost
       port: 6379
 
+  config:
+    import: classpath:api-key.yml
+


### PR DESCRIPTION
## 작업 내용
- presignedUrl를 통해 ncp object storage에 이미지를 직접 저장할 수 있도록 presignedUrl 발급 기능 추가
- owner의 shop, menu 이미지url 요청 api 추가

## 세부 사항
- 업로드 시에는 presignedUrl을 통해 이미지를 업로드 하지만, 해당 이미지가 shop,menu에 대한 이미지이고 이는 모든 유저가 볼 수 있는 이미지이기 때문에 acl을 public-read로 설정하였습니다.