### PR TITLE
[#29] LoginUser에 대한 처리를 Owner에서 전체 유저로 확장

### DIFF
--- a/api/src/main/java/com/delivery_service/common/facade/LoginUserInfoFacade.java
+++ b/api/src/main/java/com/delivery_service/common/facade/LoginUserInfoFacade.java
@@ -5,12 +5,13 @@ import com.delivery_service.common.dto.LoginUserInfo;
 import com.delivery_service.common.entity.LoginUser;
 import com.delivery_service.common.service.LoginUserInfoCacheService;
 import com.delivery_service.common.service.LoginUserService;
+import com.delivery_service.customers.entity.Customer;
+import com.delivery_service.customers.service.CustomerService;
 import com.delivery_service.owners.entity.Owner;
 import com.delivery_service.owners.service.OwnerService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @AllArgsConstructor
@@ -20,8 +21,8 @@ public class LoginUserInfoFacade {
   private final LoginUserInfoCacheService loginUserInfoCacheService;
   private final LoginUserService loginUserService;
   private final OwnerService ownerService;
+  private final CustomerService customerService;
 
-  @Transactional
   public <T> LoginUserInfo<T> getLoginUserInfo(UserRole userRole, String token, Class<T> clazz) {
 
     LoginUserInfo<T> cache = loginUserInfoCacheService.getLoginUserInfo(token, userRole);
@@ -42,7 +43,8 @@ public class LoginUserInfoFacade {
           user = clazz.cast(owner);
 
         case Customer:
-
+          Customer customer = customerService.getCustomer(loginUser.getUserId());
+          user = clazz.cast(customer);
           break;
 
         case Rider:
@@ -54,7 +56,7 @@ public class LoginUserInfoFacade {
 
     }
 
-    //캐시,db 둘 다 없을때
+    //캐시,db 둘 다 없을때 (LoginUserNotFoundException)
     return null;
   }
 
@@ -69,6 +71,7 @@ public class LoginUserInfoFacade {
         user = clazz.cast(ownerService.getOwner(userId));
         break;
       case Customer:
+        user = clazz.cast(customerService.getCustomer(userId));
         break;
       case Rider:
         break;

--- a/api/src/main/java/com/delivery_service/common/resolver/LoginUserInfoArgumentResolver.java
+++ b/api/src/main/java/com/delivery_service/common/resolver/LoginUserInfoArgumentResolver.java
@@ -3,7 +3,9 @@ package com.delivery_service.common.resolver;
 import com.delivery_service.common.UserRole;
 import com.delivery_service.common.annotation.User;
 import com.delivery_service.common.facade.LoginUserInfoFacade;
+import com.delivery_service.customers.entity.Customer;
 import com.delivery_service.owners.entity.Owner;
+import com.delivery_service.riders.entity.Rider;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,11 +29,11 @@ public class LoginUserInfoArgumentResolver implements HandlerMethodArgumentResol
     boolean hasUserAnnotation = parameter.hasParameterAnnotation(User.class);
 
     //TODO Customer.class Rider.class 추가
-    boolean isLoginUserInfo = Owner.class.isAssignableFrom(parameter.getParameterType());
-    log.debug("hasUserAnnotation = {}, isLoginUserInfo = {}", hasUserAnnotation,
-        isLoginUserInfo);
+    boolean isLoginOwnerInfo = Owner.class.isAssignableFrom(parameter.getParameterType());
+    boolean isLoginCustomerInfo = Customer.class.isAssignableFrom(parameter.getParameterType());
+    boolean isLoginRiderInfo = Rider.class.isAssignableFrom(parameter.getParameterType());
 
-    return hasUserAnnotation && isLoginUserInfo;
+    return hasUserAnnotation && (isLoginOwnerInfo || isLoginCustomerInfo || isLoginRiderInfo);
   }
 
   @Override


### PR DESCRIPTION
## 작업 내용
- LoginUserInfoArgumentResolver에서 Customer와 Rider에 대한 처리도 가능하도록 코드 추가

## 세부 사항
- supportsArgument에서 Customer,Rider객체에 대한 처리도 가능하도록 수정