### PR TITLE
[#31] Exception 및 Exception 처리 기능 추가

### DIFF
--- a/api/src/main/java/com/delivery_service/common/advice/LoginUserExceptionAdvice.java
+++ b/api/src/main/java/com/delivery_service/common/advice/LoginUserExceptionAdvice.java
@@ -1,0 +1,20 @@
+package com.delivery_service.common.advice;
+
+import com.delivery_service.common.exception.LoginRequiredException;
+import com.delivery_service.common.response.CommonResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class LoginUserExceptionAdvice {
+
+  @ExceptionHandler(LoginRequiredException.class)
+  public ResponseEntity<CommonResponse<Object>> handleLoginRequiredException(
+      LoginRequiredException e) {
+
+    return new ResponseEntity<>(CommonResponse.fail(e.getMessage()), HttpStatus.UNAUTHORIZED);
+  }
+
+}

--- a/api/src/main/java/com/delivery_service/common/advice/OwnerExceptionAdvice.java
+++ b/api/src/main/java/com/delivery_service/common/advice/OwnerExceptionAdvice.java
@@ -1,0 +1,38 @@
+package com.delivery_service.common.advice;
+
+import com.delivery_service.common.exception.MismatchedShopOwnerException;
+import com.delivery_service.common.exception.OwnerNotFoundException;
+import com.delivery_service.common.exception.ShopAlreadyExistsException;
+import com.delivery_service.common.response.CommonResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class OwnerExceptionAdvice {
+
+  @ExceptionHandler(OwnerNotFoundException.class)
+  public ResponseEntity<CommonResponse<Object>> handleOwnerNotFoundException(
+      OwnerNotFoundException e) {
+
+    return new ResponseEntity<>(CommonResponse.fail(e.getMessage()), HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(MismatchedShopOwnerException.class)
+  public ResponseEntity<CommonResponse<Object>> handleMismatchedShopOwnerException(
+      MismatchedShopOwnerException e) {
+
+    return new ResponseEntity<>(CommonResponse.fail(e.getMessage()), HttpStatus.UNAUTHORIZED);
+  }
+
+  @ExceptionHandler(ShopAlreadyExistsException.class)
+  public ResponseEntity<CommonResponse<Object>> handleShopAlreadyExistsException(
+      ShopAlreadyExistsException e) {
+
+    return new ResponseEntity<>(CommonResponse.fail(e.getMessage()), HttpStatus.BAD_REQUEST);
+  }
+
+}

--- a/api/src/main/java/com/delivery_service/common/advice/ShopExceptionAdvice.java
+++ b/api/src/main/java/com/delivery_service/common/advice/ShopExceptionAdvice.java
@@ -1,0 +1,22 @@
+package com.delivery_service.common.advice;
+
+import com.delivery_service.common.exception.ShopNotFoundException;
+import com.delivery_service.common.response.CommonResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class ShopExceptionAdvice {
+
+  @ExceptionHandler(ShopNotFoundException.class)
+  public ResponseEntity<CommonResponse<Object>> handleShopNotFoundException(
+      ShopNotFoundException e) {
+
+    return new ResponseEntity<>(CommonResponse.fail(e.getMessage()), HttpStatus.NOT_FOUND);
+  }
+
+}

--- a/api/src/main/java/com/delivery_service/common/exception/LoginRequiredException.java
+++ b/api/src/main/java/com/delivery_service/common/exception/LoginRequiredException.java
@@ -1,0 +1,9 @@
+package com.delivery_service.common.exception;
+
+public class LoginRequiredException extends RuntimeException {
+
+  public LoginRequiredException(String message) {
+    super(message);
+  }
+
+}

--- a/api/src/main/java/com/delivery_service/common/exception/MismatchedShopOwnerException.java
+++ b/api/src/main/java/com/delivery_service/common/exception/MismatchedShopOwnerException.java
@@ -1,0 +1,9 @@
+package com.delivery_service.common.exception;
+
+public class MismatchedShopOwnerException extends RuntimeException {
+
+  public MismatchedShopOwnerException(String message) {
+    super(message);
+  }
+
+}

--- a/api/src/main/java/com/delivery_service/common/exception/OwnerNotFoundException.java
+++ b/api/src/main/java/com/delivery_service/common/exception/OwnerNotFoundException.java
@@ -1,0 +1,9 @@
+package com.delivery_service.common.exception;
+
+public class OwnerNotFoundException extends RuntimeException {
+
+  public OwnerNotFoundException(Integer ownerId) {
+    super("Owner not found with id(" + ownerId + ")");
+  }
+
+}

--- a/api/src/main/java/com/delivery_service/common/exception/ShopAlreadyExistsException.java
+++ b/api/src/main/java/com/delivery_service/common/exception/ShopAlreadyExistsException.java
@@ -1,0 +1,9 @@
+package com.delivery_service.common.exception;
+
+public class ShopAlreadyExistsException extends RuntimeException {
+
+  public ShopAlreadyExistsException(String message) {
+    super(message);
+  }
+
+}

--- a/api/src/main/java/com/delivery_service/common/exception/ShopNotFoundException.java
+++ b/api/src/main/java/com/delivery_service/common/exception/ShopNotFoundException.java
@@ -1,0 +1,9 @@
+package com.delivery_service.common.exception;
+
+public class ShopNotFoundException extends RuntimeException {
+
+  public ShopNotFoundException(Integer shopId) {
+    super("Shop not found with id(" + shopId + ")");
+  }
+
+}

--- a/api/src/main/java/com/delivery_service/common/facade/LoginUserInfoFacade.java
+++ b/api/src/main/java/com/delivery_service/common/facade/LoginUserInfoFacade.java
@@ -1,8 +1,8 @@
 package com.delivery_service.common.facade;
 
-import com.delivery_service.common.UserRole;
 import com.delivery_service.common.dto.LoginUserInfo;
 import com.delivery_service.common.entity.LoginUser;
+import com.delivery_service.common.enumeration.UserRole;
 import com.delivery_service.common.service.LoginUserInfoCacheService;
 import com.delivery_service.common.service.LoginUserService;
 import com.delivery_service.customers.entity.Customer;
@@ -35,29 +35,25 @@ public class LoginUserInfoFacade {
     //캐시에 없을 때 db에서 select
     log.debug("cache miss key={}", token);
     LoginUser loginUser = loginUserService.getLoginUser(token);
-    if (loginUser != null) {
-      T user = null;
-      switch (userRole) {
-        case Owner:
-          Owner owner = ownerService.getOwner(loginUser.getUserId());
-          user = clazz.cast(owner);
 
-        case Customer:
-          Customer customer = customerService.getCustomer(loginUser.getUserId());
-          user = clazz.cast(customer);
-          break;
+    T user = null;
+    switch (userRole) {
+      case Owner:
+        Owner owner = ownerService.getOwner(loginUser.getUserId());
+        user = clazz.cast(owner);
 
-        case Rider:
-          break;
+      case Customer:
+        Customer customer = customerService.getCustomer(loginUser.getUserId());
+        user = clazz.cast(customer);
+        break;
 
-      }
-
-      return new LoginUserInfo<T>(loginUser, user);
+      case Rider:
+        break;
 
     }
 
-    //캐시,db 둘 다 없을때 (LoginUserNotFoundException)
-    return null;
+    return new LoginUserInfo<T>(loginUser, user);
+
   }
 
   public <T> T saveLoginUserInfo(UserRole userRole, String token, Class<T> clazz, Integer userId) {

--- a/api/src/main/java/com/delivery_service/common/resolver/LoginUserInfoArgumentResolver.java
+++ b/api/src/main/java/com/delivery_service/common/resolver/LoginUserInfoArgumentResolver.java
@@ -1,7 +1,8 @@
 package com.delivery_service.common.resolver;
 
-import com.delivery_service.common.UserRole;
 import com.delivery_service.common.annotation.User;
+import com.delivery_service.common.enumeration.UserRole;
+import com.delivery_service.common.exception.LoginRequiredException;
 import com.delivery_service.common.facade.LoginUserInfoFacade;
 import com.delivery_service.customers.entity.Customer;
 import com.delivery_service.owners.entity.Owner;
@@ -49,7 +50,7 @@ public class LoginUserInfoArgumentResolver implements HandlerMethodArgumentResol
 
       return loginUserInfoFacade.getLoginUserInfo(userRole, token, userRole.getClazz()).getUser();
     }
-    return null;
+    throw new LoginRequiredException("login required");
   }
 
 

--- a/api/src/main/java/com/delivery_service/common/service/LoginUserService.java
+++ b/api/src/main/java/com/delivery_service/common/service/LoginUserService.java
@@ -1,7 +1,8 @@
 package com.delivery_service.common.service;
 
-import com.delivery_service.common.UserRole;
 import com.delivery_service.common.entity.LoginUser;
+import com.delivery_service.common.enumeration.UserRole;
+import com.delivery_service.common.exception.LoginRequiredException;
 import com.delivery_service.common.repository.LoginUserRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,11 +18,13 @@ public class LoginUserService {
   }
 
   public LoginUser getLoginUser(String token) {
-    return repository.findById(token).get();
+    return repository.findById(token)
+        .orElseThrow(() -> new LoginRequiredException("login required"));
   }
 
   public LoginUser getLoginUserByRoleAndUserId(UserRole role, Integer userId) {
-    return repository.findByRoleAndUserId(role, userId).get();
+    return repository.findByRoleAndUserId(role, userId)
+        .orElseThrow(() -> new LoginRequiredException("login required"));
   }
 
 }

--- a/api/src/main/java/com/delivery_service/owners/facade/OwnerShopFacade.java
+++ b/api/src/main/java/com/delivery_service/owners/facade/OwnerShopFacade.java
@@ -1,8 +1,8 @@
 package com.delivery_service.owners.facade;
 
-import com.delivery_service.common.UserRole;
 import com.delivery_service.common.dto.LoginUserInfo;
 import com.delivery_service.common.entity.LoginUser;
+import com.delivery_service.common.enumeration.UserRole;
 import com.delivery_service.common.service.ImageUrlService;
 import com.delivery_service.common.service.LoginUserInfoCacheService;
 import com.delivery_service.common.service.LoginUserService;
@@ -16,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @AllArgsConstructor
 @Component
-@Transactional
 public class OwnerShopFacade {
 
   private final OwnerService ownerService;
@@ -25,6 +24,7 @@ public class OwnerShopFacade {
   private final LoginUserInfoCacheService loginUserInfoCacheService;
   private final ImageUrlService imageUrlService;
 
+  @Transactional
   public Shop addShop(Owner owner, Shop shop) {
     Shop savedShop = ownerShopService.addShop(owner, shop);
     owner.setShopId(savedShop.getId());

--- a/api/src/main/java/com/delivery_service/owners/service/OwnerService.java
+++ b/api/src/main/java/com/delivery_service/owners/service/OwnerService.java
@@ -1,5 +1,6 @@
 package com.delivery_service.owners.service;
 
+import com.delivery_service.common.exception.OwnerNotFoundException;
 import com.delivery_service.owners.entity.Owner;
 import com.delivery_service.owners.repository.OwnerRepository;
 import lombok.AllArgsConstructor;
@@ -12,7 +13,7 @@ public class OwnerService {
   private final OwnerRepository repository;
 
   public Owner getOwner(Integer ownerId) {
-    return repository.findById(ownerId).get();
+    return repository.findById(ownerId).orElseThrow(() -> new OwnerNotFoundException(ownerId));
   }
 
   public void updateOwner(Owner owner) {

--- a/api/src/main/java/com/delivery_service/owners/service/OwnerShopService.java
+++ b/api/src/main/java/com/delivery_service/owners/service/OwnerShopService.java
@@ -1,5 +1,8 @@
 package com.delivery_service.owners.service;
 
+import com.delivery_service.common.exception.MismatchedShopOwnerException;
+import com.delivery_service.common.exception.ShopAlreadyExistsException;
+import com.delivery_service.common.exception.ShopNotFoundException;
 import com.delivery_service.owners.entity.Owner;
 import com.delivery_service.owners.entity.Shop;
 import com.delivery_service.owners.repository.OwnerShopRepository;
@@ -15,7 +18,7 @@ public class OwnerShopService {
 
   public Shop addShop(Owner owner, Shop shop) {
     if (owner.getShopId() != null) {
-      return null;
+      throw new ShopAlreadyExistsException("Owner already has a shop");
     }
 
     Shop savedShop = repository.save(shop);
@@ -24,35 +27,32 @@ public class OwnerShopService {
   }
 
   public Shop getShop(Owner owner) {
-    if (owner.getShopId() == null) {
-      return null;
-    }
-    return repository.findById(owner.getShopId()).get();
+    return repository.findById(owner.getShopId())
+        .orElseThrow(() -> new ShopNotFoundException(owner.getShopId()));
   }
 
   public Shop updateShop(Owner owner, Shop updatedShop) {
     if (!updatedShop.getId().equals(owner.getShopId())) {
-      return null;
+      throw new MismatchedShopOwnerException("Owner shop id doesn't match");
     }
     Optional<Shop> optionalShop = repository.findById(owner.getId());
-    if (optionalShop.isPresent()) {
-      Shop shop = optionalShop.get();
-      shop.setName(updatedShop.getName());
-      shop.setDescription(updatedShop.getDescription());
-      //TODO address가 바뀌면 latitude,longitude도 바뀌어야 한다.
-      shop.setAddress(updatedShop.getAddress());
-      shop.setCategory(updatedShop.getCategory());
-      shop.setImage(updatedShop.getImage());
+    Shop shop = optionalShop.orElseThrow(() -> new ShopNotFoundException(owner.getId()));
 
-      return shop;
-    }
+    shop.setName(updatedShop.getName());
+    shop.setDescription(updatedShop.getDescription());
+    //TODO address가 바뀌면 latitude,longitude도 바뀌어야 한다.
+    shop.setAddress(updatedShop.getAddress());
+    shop.setCategory(updatedShop.getCategory());
+    shop.setImage(updatedShop.getImage());
 
-    return null;
+    return shop;
+
 
   }
 
   public Boolean updateShopStatus(Owner owner, Boolean isOpen) {
-    Shop shop = repository.findById(owner.getShopId()).get();
+    Shop shop = repository.findById(owner.getShopId())
+        .orElseThrow(() -> new ShopNotFoundException(owner.getShopId()));
     shop.setIsOpen(isOpen);
     return shop.getIsOpen();
   }


### PR DESCRIPTION
## 작업 내용
- Owner 및 Owner의 Shop 관련 기능에 대한 Exception 처리
- LoginUser 기능에 대한 Exception 처리

## 세부 사항
- 예외 상황에 맞게 RuntimeException을 상속하는 Custom한 Exception을 구현하여 사용하였습니다.
- 예외 처리는 RestControllerAdvice와 ExceptionHandler 어노테이션을 사용하여 기존에 구현한 공통응답객체(CommonResponse)를 사용할 수 있도록 하였습니다.
- 다른 기능에서의 예외처리는 추가하겠습니다.

## 고민 사항
- 모든 예외 처리를 공통 응답 객체로 처리하고, exception의 메세지를 필드에 담습니다. 그러다보니 exception생성자로 넘겨지는 메시지만 다르면 되지 않은가? 라는 의문이 생깁니다. 예외 상황마다 Exception 클래스를 작성하고, Handler처리 부분을 결국 똑같이 처리하고 있기 때문입니다.  물론 한번에 처리하려고 하는 저의 개발 습관 때문일 수도 있습니다.
