### PR TITLE
[#33] 이미지 업로드 url api 분리

### DIFF
--- a/.github/workflows/ci-gradle-test.yml
+++ b/.github/workflows/ci-gradle-test.yml
@@ -1,0 +1,35 @@
+name: CI With Gradle
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      API_KEY: ${{ secrets.API_KEY_YML }}
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Create api-key.yml
+        run: echo "$API_KEY" > api/src/main/resources/api-key.yml
+
+      - name: Docker Compose Up
+        run: docker compose up -d
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Set file permissions for Gradle
+        run: chmod +x ./gradlew
+
+      - name: Test with Gradle Wrapper
+        run: ./gradlew test

--- a/api/src/main/java/com/delivery_service/common/ImageUrlProvider.java
+++ b/api/src/main/java/com/delivery_service/common/ImageUrlProvider.java
@@ -1,0 +1,20 @@
+package com.delivery_service.common;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ImageUrlProvider {
+
+  //  private static final String publicUrl = "https://delivery-service.kr.object.ncloudstorage.com/";
+  private static String publicUrl;
+
+  @Value("${ncp.storage.public-url}")
+  public void setPublicUrl(String publicUrl) {
+    this.publicUrl = publicUrl;
+  }
+
+  public static String getPublicUrl(String fileName) {
+    return publicUrl + fileName;
+  }
+}

--- a/api/src/main/java/com/delivery_service/common/advice/LoginUserExceptionAdvice.java
+++ b/api/src/main/java/com/delivery_service/common/advice/LoginUserExceptionAdvice.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class LoginUserExceptionAdvice {
 
   @ExceptionHandler(LoginRequiredException.class)
-  public ResponseEntity<CommonResponse<Object>> handleLoginRequiredException(
+  public ResponseEntity<CommonResponse<Void>> handleLoginRequiredException(
       LoginRequiredException e) {
 
     return new ResponseEntity<>(CommonResponse.fail(e.getMessage()), HttpStatus.UNAUTHORIZED);

--- a/api/src/main/java/com/delivery_service/common/advice/OwnerExceptionAdvice.java
+++ b/api/src/main/java/com/delivery_service/common/advice/OwnerExceptionAdvice.java
@@ -15,21 +15,21 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class OwnerExceptionAdvice {
 
   @ExceptionHandler(OwnerNotFoundException.class)
-  public ResponseEntity<CommonResponse<Object>> handleOwnerNotFoundException(
+  public ResponseEntity<CommonResponse<Void>> handleOwnerNotFoundException(
       OwnerNotFoundException e) {
 
     return new ResponseEntity<>(CommonResponse.fail(e.getMessage()), HttpStatus.NOT_FOUND);
   }
 
   @ExceptionHandler(MismatchedShopOwnerException.class)
-  public ResponseEntity<CommonResponse<Object>> handleMismatchedShopOwnerException(
+  public ResponseEntity<CommonResponse<Void>> handleMismatchedShopOwnerException(
       MismatchedShopOwnerException e) {
 
     return new ResponseEntity<>(CommonResponse.fail(e.getMessage()), HttpStatus.UNAUTHORIZED);
   }
 
   @ExceptionHandler(ShopAlreadyExistsException.class)
-  public ResponseEntity<CommonResponse<Object>> handleShopAlreadyExistsException(
+  public ResponseEntity<CommonResponse<Void>> handleShopAlreadyExistsException(
       ShopAlreadyExistsException e) {
 
     return new ResponseEntity<>(CommonResponse.fail(e.getMessage()), HttpStatus.BAD_REQUEST);

--- a/api/src/main/java/com/delivery_service/common/advice/ShopExceptionAdvice.java
+++ b/api/src/main/java/com/delivery_service/common/advice/ShopExceptionAdvice.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class ShopExceptionAdvice {
 
   @ExceptionHandler(ShopNotFoundException.class)
-  public ResponseEntity<CommonResponse<Object>> handleShopNotFoundException(
+  public ResponseEntity<CommonResponse<Void>> handleShopNotFoundException(
       ShopNotFoundException e) {
 
     return new ResponseEntity<>(CommonResponse.fail(e.getMessage()), HttpStatus.NOT_FOUND);

--- a/api/src/main/java/com/delivery_service/common/annotation/User.java
+++ b/api/src/main/java/com/delivery_service/common/annotation/User.java
@@ -1,6 +1,6 @@
 package com.delivery_service.common.annotation;
 
-import com.delivery_service.common.UserRole;
+import com.delivery_service.common.enumeration.UserRole;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/api/src/main/java/com/delivery_service/common/controller/ImageUrlController.java
+++ b/api/src/main/java/com/delivery_service/common/controller/ImageUrlController.java
@@ -1,0 +1,30 @@
+package com.delivery_service.common.controller;
+
+import com.delivery_service.common.dto.ImageUploadReqDto;
+import com.delivery_service.common.dto.ImageUrlDto;
+import com.delivery_service.common.response.CommonResponse;
+import com.delivery_service.common.service.ImageUrlService;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@AllArgsConstructor
+public class ImageUrlController {
+
+  private final ImageUrlService imageUrlService;
+
+  @PostMapping("/request/image-url")
+  public ResponseEntity<CommonResponse<ImageUrlDto>> getShopImageUrl(
+      @RequestBody ImageUploadReqDto imageUploadReqDto) {
+    ImageUrlDto imageUrlDto = imageUrlService.getImageUrlDto(
+        imageUploadReqDto.getOriginalImageName());
+
+    CommonResponse<ImageUrlDto> response = CommonResponse.success(imageUrlDto);
+
+    return new ResponseEntity<>(response, HttpStatus.OK);
+  }
+}

--- a/api/src/main/java/com/delivery_service/common/dto/ImageUrlDto.java
+++ b/api/src/main/java/com/delivery_service/common/dto/ImageUrlDto.java
@@ -2,12 +2,14 @@ package com.delivery_service.common.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 
 @AllArgsConstructor
 @Getter
+@ToString
 public class ImageUrlDto {
 
   private String urlForUpload;
-  private String urlForDownload;
+  private String imageFileName;
 
 }

--- a/api/src/main/java/com/delivery_service/common/entity/LoginUser.java
+++ b/api/src/main/java/com/delivery_service/common/entity/LoginUser.java
@@ -1,6 +1,6 @@
 package com.delivery_service.common.entity;
 
-import com.delivery_service.common.UserRole;
+import com.delivery_service.common.enumeration.UserRole;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;

--- a/api/src/main/java/com/delivery_service/common/enumeration/UserRole.java
+++ b/api/src/main/java/com/delivery_service/common/enumeration/UserRole.java
@@ -1,9 +1,9 @@
-package com.delivery_service.common;
+package com.delivery_service.common.enumeration;
 
 public enum UserRole {
   Owner(com.delivery_service.owners.entity.Owner.class),
-  Customer(null),
-  Rider(null);
+  Customer(com.delivery_service.customers.entity.Customer.class),
+  Rider(com.delivery_service.riders.entity.Rider.class);
 
   private final Class clazz;
 

--- a/api/src/main/java/com/delivery_service/common/repository/LoginUserRepository.java
+++ b/api/src/main/java/com/delivery_service/common/repository/LoginUserRepository.java
@@ -1,7 +1,7 @@
 package com.delivery_service.common.repository;
 
-import com.delivery_service.common.UserRole;
 import com.delivery_service.common.entity.LoginUser;
+import com.delivery_service.common.enumeration.UserRole;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/api/src/main/java/com/delivery_service/common/service/LoginUserInfoCacheService.java
+++ b/api/src/main/java/com/delivery_service/common/service/LoginUserInfoCacheService.java
@@ -1,7 +1,7 @@
 package com.delivery_service.common.service;
 
-import com.delivery_service.common.UserRole;
 import com.delivery_service.common.dto.LoginUserInfo;
+import com.delivery_service.common.enumeration.UserRole;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;

--- a/api/src/main/java/com/delivery_service/customers/controller/ShopController.java
+++ b/api/src/main/java/com/delivery_service/customers/controller/ShopController.java
@@ -1,8 +1,8 @@
 package com.delivery_service.customers.controller;
 
 import com.delivery_service.common.response.CommonResponse;
-import com.delivery_service.customers.service.CustomerMenuService;
-import com.delivery_service.customers.service.CustomerShopService;
+import com.delivery_service.customers.service.MenuService;
+import com.delivery_service.customers.service.ShopService;
 import com.delivery_service.owners.dto.MenuInfoDto;
 import com.delivery_service.owners.dto.ShopInfoDto;
 import com.delivery_service.owners.entity.Menu;
@@ -12,32 +12,33 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @AllArgsConstructor
 @RequestMapping("/shops")
-public class CustomerShopController {
+public class ShopController {
 
-  private final CustomerShopService customerShopService;
-  private final CustomerMenuService customerMenuService;
+  private final ShopService shopService;
+  private final MenuService menuService;
 
-  @GetMapping("/${shopId}")
-  public ResponseEntity<CommonResponse<ShopInfoDto>> getShop(@PathVariable int shopId) {
-    Shop shop = customerShopService.getShop(shopId);
+  @GetMapping("/{shopId}")
+  public ResponseEntity<CommonResponse<ShopInfoDto>> getShop(
+      @PathVariable("shopId") Integer shopId) {
+    Shop shop = shopService.getShop(shopId);
     CommonResponse<ShopInfoDto> response = CommonResponse.success(ShopInfoDto.convertToDto(shop));
 
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
-  @GetMapping("/${shopId}/menus")
+  @GetMapping("/{shopId}/menus")
   public ResponseEntity<CommonResponse<ArrayList<MenuInfoDto>>> getShopMenus(
-      @PathVariable int shopId) {
+      @PathVariable("shopId") Integer shopId) {
     ArrayList<MenuInfoDto> MenusDto = new ArrayList<>();
-    List<Menu> menus = customerMenuService.getAllMenus(shopId);
+    List<Menu> menus = menuService.getAllMenus(shopId);
     for (Menu menu : menus) {
       MenusDto.add(MenuInfoDto.convertToDto(menu));
     }
@@ -47,11 +48,12 @@ public class CustomerShopController {
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
-  @GetMapping("/${shopId}/menus/${menuId}")
-  public ResponseEntity<CommonResponse<MenuInfoDto>> getShopMenu(@PathVariable int shopId,
-      @PathVariable int menuId) {
+  @GetMapping("/{shopId}/menus/{menuId}")
+  public ResponseEntity<CommonResponse<MenuInfoDto>> getShopMenu(
+      @PathVariable("shopId") Integer shopId,
+      @PathVariable("menuId") Integer menuId) {
     //shopId의 필요성...
-    Menu menu = customerMenuService.getMenu(menuId);
+    Menu menu = menuService.getMenu(menuId);
 
     CommonResponse<MenuInfoDto> response = CommonResponse.success(MenuInfoDto.convertToDto(menu));
     return new ResponseEntity<>(response, HttpStatus.OK);

--- a/api/src/main/java/com/delivery_service/customers/service/MenuService.java
+++ b/api/src/main/java/com/delivery_service/customers/service/MenuService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @AllArgsConstructor
-public class CustomerMenuService {
+public class MenuService {
 
   private final CustomerMenuRepository repository;
 

--- a/api/src/main/java/com/delivery_service/customers/service/ShopService.java
+++ b/api/src/main/java/com/delivery_service/customers/service/ShopService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @AllArgsConstructor
-public class CustomerShopService {
+public class ShopService {
 
   private final CustomerShopRepository repository;
 

--- a/api/src/main/java/com/delivery_service/owners/controller/OwnerMenuController.java
+++ b/api/src/main/java/com/delivery_service/owners/controller/OwnerMenuController.java
@@ -1,11 +1,9 @@
 package com.delivery_service.owners.controller;
 
-import com.delivery_service.common.UserRole;
+import com.delivery_service.common.ImageUrlProvider;
 import com.delivery_service.common.annotation.User;
-import com.delivery_service.common.dto.ImageUploadReqDto;
-import com.delivery_service.common.dto.ImageUrlDto;
+import com.delivery_service.common.enumeration.UserRole;
 import com.delivery_service.common.response.CommonResponse;
-import com.delivery_service.common.service.ImageUrlService;
 import com.delivery_service.owners.dto.MenuInfoDto;
 import com.delivery_service.owners.dto.MenuRegisterDto;
 import com.delivery_service.owners.dto.MenuStatusDto;
@@ -32,7 +30,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class OwnerMenuController {
 
   private final OwnerMenuService ownerMenuService;
-  private final ImageUrlService imageUrlService;
 
   @PostMapping
   public ResponseEntity<CommonResponse<MenuInfoDto>> addMenu(
@@ -76,28 +73,15 @@ public class OwnerMenuController {
     ArrayList<MenuInfoDto> MenusDto = new ArrayList<>();
     List<Menu> menus = ownerMenuService.getAllMenus(owner.getShopId());
     for (Menu menu : menus) {
-      MenusDto.add(MenuInfoDto.convertToDto(menu));
+      MenuInfoDto menuInfoDto = MenuInfoDto.convertToDto(menu);
+      menuInfoDto.setImage(ImageUrlProvider.getPublicUrl(menuInfoDto.getImage()));
+      MenusDto.add(menuInfoDto);
+
     }
 
     CommonResponse<ArrayList<MenuInfoDto>> response = CommonResponse.success(MenusDto);
 
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
-
-  @PostMapping("/image-url")
-  public ResponseEntity<CommonResponse<ImageUrlDto>> getShopImageUrl(
-      @User(role = UserRole.Owner) Owner owner, @RequestBody ImageUploadReqDto imageUploadReqDto) {
-
-    String shopImageUploadUrl = imageUrlService.getPresignedUrl(ImageUrlService.USAGE_MENU,
-        imageUploadReqDto.getOriginalImageName());
-    String shopImageDownloadUrl = imageUrlService.getPublicUrl(shopImageUploadUrl);
-
-    ImageUrlDto imageUrlDto = new ImageUrlDto(shopImageUploadUrl, shopImageDownloadUrl);
-
-    CommonResponse<ImageUrlDto> response = CommonResponse.success(imageUrlDto);
-
-    return new ResponseEntity<>(response, HttpStatus.OK);
-  }
-
 
 }

--- a/api/src/main/java/com/delivery_service/owners/controller/OwnerShopController.java
+++ b/api/src/main/java/com/delivery_service/owners/controller/OwnerShopController.java
@@ -1,9 +1,8 @@
 package com.delivery_service.owners.controller;
 
-import com.delivery_service.common.UserRole;
+import com.delivery_service.common.ImageUrlProvider;
 import com.delivery_service.common.annotation.User;
-import com.delivery_service.common.dto.ImageUploadReqDto;
-import com.delivery_service.common.dto.ImageUrlDto;
+import com.delivery_service.common.enumeration.UserRole;
 import com.delivery_service.common.response.CommonResponse;
 import com.delivery_service.owners.dto.ShopInfoDto;
 import com.delivery_service.owners.dto.ShopRegisterDto;
@@ -51,9 +50,10 @@ public class OwnerShopController {
     log.debug("owner = {}", owner);
     Shop shop = ownerShopFacade.getShop(owner);
     log.debug("shop = {}", shop);
-
+    ShopInfoDto shopInfoDto = ShopInfoDto.convertToDto(shop);
+    shopInfoDto.setImage(ImageUrlProvider.getPublicUrl(shopInfoDto.getImage()));
     CommonResponse<ShopInfoDto> response = CommonResponse.success(
-        ShopInfoDto.convertToDto(shop));
+        shopInfoDto);
 
     return new ResponseEntity<>(response, HttpStatus.OK);
 
@@ -84,20 +84,6 @@ public class OwnerShopController {
     shopStatusDto.setIsOpen(isOpen);
 
     CommonResponse<ShopStatusDto> response = CommonResponse.success(shopStatusDto);
-
-    return new ResponseEntity<>(response, HttpStatus.OK);
-  }
-
-  @PostMapping("/image-url")
-  public ResponseEntity<CommonResponse<ImageUrlDto>> getShopImageUrl(
-      @User(role = UserRole.Owner) Owner owner, @RequestBody ImageUploadReqDto imageUploadReqDto) {
-    String shopImageUploadUrl = ownerShopFacade.getShopImageUploadUrl(
-        imageUploadReqDto.getOriginalImageName());
-    String shopImageDownloadUrl = ownerShopFacade.getShopImageDownloadUrl(shopImageUploadUrl);
-
-    ImageUrlDto imageUrlDto = new ImageUrlDto(shopImageUploadUrl, shopImageDownloadUrl);
-
-    CommonResponse<ImageUrlDto> response = CommonResponse.success(imageUrlDto);
 
     return new ResponseEntity<>(response, HttpStatus.OK);
   }

--- a/api/src/main/java/com/delivery_service/owners/dto/ShopRegisterDto.java
+++ b/api/src/main/java/com/delivery_service/owners/dto/ShopRegisterDto.java
@@ -14,6 +14,7 @@ public class ShopRegisterDto {
   private String description;
   private String address;
   private String category;
+  private String image;
 
   public Shop convertToEntity() {
     Shop entity = new Shop();
@@ -22,6 +23,7 @@ public class ShopRegisterDto {
     entity.setAddress(address);
     entity.setIsOpen(false);
     entity.setCategory(category);
+    entity.setImage(image);
 
     return entity;
   }

--- a/api/src/main/java/com/delivery_service/owners/facade/OwnerShopFacade.java
+++ b/api/src/main/java/com/delivery_service/owners/facade/OwnerShopFacade.java
@@ -3,7 +3,6 @@ package com.delivery_service.owners.facade;
 import com.delivery_service.common.dto.LoginUserInfo;
 import com.delivery_service.common.entity.LoginUser;
 import com.delivery_service.common.enumeration.UserRole;
-import com.delivery_service.common.service.ImageUrlService;
 import com.delivery_service.common.service.LoginUserInfoCacheService;
 import com.delivery_service.common.service.LoginUserService;
 import com.delivery_service.owners.entity.Owner;
@@ -22,7 +21,6 @@ public class OwnerShopFacade {
   private final OwnerShopService ownerShopService;
   private final LoginUserService loginUserService;
   private final LoginUserInfoCacheService loginUserInfoCacheService;
-  private final ImageUrlService imageUrlService;
 
   @Transactional
   public Shop addShop(Owner owner, Shop shop) {

--- a/api/src/main/java/com/delivery_service/owners/facade/OwnerShopFacade.java
+++ b/api/src/main/java/com/delivery_service/owners/facade/OwnerShopFacade.java
@@ -37,6 +37,7 @@ public class OwnerShopFacade {
     return savedShop;
   }
 
+
   public Shop getShop(Owner owner) {
     return ownerShopService.getShop(owner);
   }
@@ -47,14 +48,6 @@ public class OwnerShopFacade {
 
   public Boolean updateShopStatus(Owner owner, Boolean isOpen) {
     return ownerShopService.updateShopStatus(owner, isOpen);
-  }
-
-  public String getShopImageUploadUrl(String originalImageName) {
-    return imageUrlService.getPresignedUrl(ImageUrlService.USAGE_SHOP, originalImageName);
-  }
-
-  public String getShopImageDownloadUrl(String presignedUrl) {
-    return imageUrlService.getPublicUrl(presignedUrl);
   }
 
 

--- a/api/src/main/java/com/delivery_service/owners/service/OwnerShopService.java
+++ b/api/src/main/java/com/delivery_service/owners/service/OwnerShopService.java
@@ -36,25 +36,24 @@ public class OwnerShopService {
       throw new MismatchedShopOwnerException("Owner shop id doesn't match");
     }
     Optional<Shop> optionalShop = repository.findById(owner.getId());
-    Shop shop = optionalShop.orElseThrow(() -> new ShopNotFoundException(owner.getId()));
 
-    shop.setName(updatedShop.getName());
-    shop.setDescription(updatedShop.getDescription());
-    //TODO address가 바뀌면 latitude,longitude도 바뀌어야 한다.
-    shop.setAddress(updatedShop.getAddress());
-    shop.setCategory(updatedShop.getCategory());
-    shop.setImage(updatedShop.getImage());
-
-    return shop;
-
-
+    return optionalShop.map(shop -> {
+      shop.setName(updatedShop.getName());
+      shop.setDescription(updatedShop.getDescription());
+      //TODO address가 바뀌면 latitude,longitude도 바뀌어야 한다.
+      shop.setAddress(updatedShop.getAddress());
+      shop.setCategory(updatedShop.getCategory());
+      shop.setImage(updatedShop.getImage());
+      return shop;
+    }).orElseThrow(() -> new ShopNotFoundException(owner.getId()));
   }
 
   public Boolean updateShopStatus(Owner owner, Boolean isOpen) {
-    Shop shop = repository.findById(owner.getShopId())
-        .orElseThrow(() -> new ShopNotFoundException(owner.getShopId()));
-    shop.setIsOpen(isOpen);
-    return shop.getIsOpen();
+
+    return repository.findById(owner.getShopId()).map(shop -> {
+      shop.setIsOpen(isOpen);
+      return shop.getIsOpen();
+    }).orElseThrow(() -> new ShopNotFoundException(owner.getShopId()));
   }
 
 }

--- a/api/src/main/java/com/delivery_service/riders/entity/Rider.java
+++ b/api/src/main/java/com/delivery_service/riders/entity/Rider.java
@@ -1,0 +1,7 @@
+package com.delivery_service.riders.entity;
+
+public class Rider {
+
+  private Integer id;
+
+}

--- a/api/src/main/resources/before-test.sql
+++ b/api/src/main/resources/before-test.sql
@@ -1,6 +1,8 @@
+SET foreign_key_checks = 0;
 TRUNCATE TABLE owner;
 TRUNCATE TABLE shop;
 TRUNCATE TABLE login_user;
+SET foreign_key_checks = 1;
 
 INSERT INTO owner (shop_id)
 VALUES (NULL),

--- a/api/src/test/java/com/delivery_service/owners/controller/ImageUrlControllerTest.java
+++ b/api/src/test/java/com/delivery_service/owners/controller/ImageUrlControllerTest.java
@@ -1,0 +1,47 @@
+package com.delivery_service.owners.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.delivery_service.common.dto.ImageUploadReqDto;
+import com.delivery_service.common.dto.ImageUrlDto;
+import com.delivery_service.common.response.CommonResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Slf4j
+public class ImageUrlControllerTest {
+
+  @Autowired
+  private TestRestTemplate testRestTemplate;
+
+  @Test
+  void getImageUrl() {
+    String originalFileName = "image.jpg";
+    ImageUploadReqDto imageUploadReqDto = new ImageUploadReqDto(originalFileName);
+
+    HttpEntity<ImageUploadReqDto> request = new HttpEntity<>(imageUploadReqDto);
+    ResponseEntity<CommonResponse<ImageUrlDto>> response = testRestTemplate.exchange(
+        "/request/image-url",
+        HttpMethod.POST, request, new ParameterizedTypeReference<CommonResponse<ImageUrlDto>>() {
+        });
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().getData()).isNotNull();
+    ImageUrlDto imageUrlDto = response.getBody().getData();
+    assertThat(imageUrlDto.getUrlForUpload()).isNotNull();
+    assertThat(imageUrlDto.getImageFileName()).isNotNull();
+
+    log.debug(imageUrlDto.toString());
+
+  }
+
+}

--- a/api/src/test/java/com/delivery_service/owners/controller/OwnerShopControllerIntegrationTest.java
+++ b/api/src/test/java/com/delivery_service/owners/controller/OwnerShopControllerIntegrationTest.java
@@ -2,7 +2,7 @@ package com.delivery_service.owners.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.delivery_service.common.UserRole;
+import com.delivery_service.common.enumeration.UserRole;
 import com.delivery_service.common.facade.LoginUserInfoFacade;
 import com.delivery_service.common.response.CommonResponse;
 import com.delivery_service.owners.dto.ShopInfoDto;
@@ -62,6 +62,7 @@ class OwnerShopControllerIntegrationTest {
     shopRegisterDto.setDescription("버거 맛있음");
     shopRegisterDto.setCategory("패스트푸드");
     shopRegisterDto.setAddress("서울시 강서구 양천로23길 9");
+    shopRegisterDto.setImage("image.jpg");
 
     String token = setLoginInfo();
     HttpHeaders headers = new HttpHeaders();
@@ -110,6 +111,9 @@ class OwnerShopControllerIntegrationTest {
     assertThat(shopInfoDto.getCategory()).isEqualTo(addedShopInfoDto.getCategory());
     assertThat(shopInfoDto.getAddress()).isEqualTo(addedShopInfoDto.getAddress());
     assertThat(shopInfoDto.getIsOpen()).isEqualTo(addedShopInfoDto.getIsOpen());
+    if (shopInfoDto.getImage() != null) {
+      log.debug("image={}", shopInfoDto.getImage());
+    }
 
   }
 
@@ -182,6 +186,7 @@ class OwnerShopControllerIntegrationTest {
     shopRegisterDto.setDescription("버거 맛있음");
     shopRegisterDto.setCategory("패스트푸드");
     shopRegisterDto.setAddress("서울시 강서구 양천로23길 9");
+    shopRegisterDto.setImage("image.jpg");
 
     String token = setLoginInfo();
     HttpHeaders headers = new HttpHeaders();


### PR DESCRIPTION
## 작업 내용
- 기존 이미지용 presignedUrl 요청 api를 공통 api로 분리
- 이미지 저장 로직 일부 수정
- exception에 대한 공통 응답 객체에서 Object 가 아닌 Void로 변경

## 세부 사항
- 응답데이터에 presignedUrl과 키가 되는 fileName만 전송하도록 하였습니다.
- 마찬가지로 db에도 fileName만 저장하고, client 요청시 url(domain+key)로 파싱하여 전송하도록 수정하였습니다.
- 추가로 일부 파일 명 변경과 패키지 이동이 있습니다. 실수로 같이 commit 했습니다. 죄송합니다